### PR TITLE
Fix CRC32 functions name for Postgres >= 9.5.

### DIFF
--- a/data.c
+++ b/data.c
@@ -68,7 +68,11 @@ doDeflate(z_stream *zp, size_t in_size, size_t out_size, void *inbuf,
 		}
 
 		/* update CRC */
+#ifdef PG_CRC32C_H
+		COMP_CRC32C(*crc, outbuf, out_size - zp->avail_out);
+#else
 		COMP_CRC32(*crc, outbuf, out_size - zp->avail_out);
+#endif
 
 		*write_size += out_size - zp->avail_out;
 
@@ -146,7 +150,11 @@ doInflate(z_stream *zp, size_t in_size, size_t out_size,void *inbuf,
 	}
 
 	/* update CRC */
+#ifdef PG_CRC32C_H
+	COMP_CRC32C(*crc, outbuf, out_size - zp->avail_out);
+#else
 	COMP_CRC32(*crc, outbuf, out_size - zp->avail_out);
+#endif
 
 	return status;
 }
@@ -216,7 +224,11 @@ backup_data_file(const char *from_root, const char *to_root,
 	z_stream			z;
 	char				outbuf[zlibOutSize];
 #endif
+#ifdef PG_CRC32C_H
+	INIT_CRC32C(crc);
+#else
 	INIT_CRC32(crc);
+#endif
 
 	/* reset size summary */
 	file->read_size = 0;
@@ -226,7 +238,11 @@ backup_data_file(const char *from_root, const char *to_root,
 	in = fopen(file->path, "r");
 	if (in == NULL)
 	{
+#ifdef PG_CRC32C_H
+		FIN_CRC32C(crc);
+#else
 		FIN_CRC32(crc);
+#endif
 		file->crc = crc;
 
 		/* maybe vanished, it's not error */
@@ -338,9 +354,15 @@ backup_data_file(const char *from_root, const char *to_root,
 			}
 
 			/* update CRC */
+#ifdef PG_CRC32C_H
+			COMP_CRC32C(crc, &header, sizeof(header));
+			COMP_CRC32C(crc, page.data, header.hole_offset);
+			COMP_CRC32C(crc, page.data + upper_offset, upper_length);
+#else
 			COMP_CRC32(crc, &header, sizeof(header));
 			COMP_CRC32(crc, page.data, header.hole_offset);
 			COMP_CRC32(crc, page.data + upper_offset, upper_length);
+#endif
 
 			file->write_size += sizeof(header) + read_len - header.hole_length;
 		}
@@ -393,7 +415,11 @@ backup_data_file(const char *from_root, const char *to_root,
 						 _("can't write at block %u of \"%s\": %s"),
 						 blknum, to_path, strerror(errno_tmp));
 				}
+#ifdef PG_CRC32C_H
+				COMP_CRC32C(crc, &header, sizeof(header));
+#else
 				COMP_CRC32(crc, &header, sizeof(header));
+#endif
 				file->write_size += sizeof(header);
 			}
 		}
@@ -417,8 +443,11 @@ backup_data_file(const char *from_root, const char *to_root,
 				elog(ERROR_SYSTEM, _("can't write at block %u of \"%s\": %s"),
 					blknum, to_path, strerror(errno_tmp));
 			}
-
+#ifdef PG_CRC32C_H
+			COMP_CRC32C(crc, page.data, read_len);
+#else
 			COMP_CRC32(crc, page.data, read_len);
+#endif
 			file->write_size += read_len;
 		}
 
@@ -462,7 +491,11 @@ backup_data_file(const char *from_root, const char *to_root,
 	fclose(out);
 
 	/* finish CRC calculation and store into pgFile */
+#ifdef PG_CRC32C_H
+	FIN_CRC32C(crc);
+#else
 	FIN_CRC32(crc);
+#endif
 	file->crc = crc;
 
 	/* Treat empty file as not-datafile */
@@ -553,7 +586,11 @@ restore_data_file(const char *from_root,
 		if (inflateInit(&z) != Z_OK)
 			elog(ERROR_SYSTEM, _("can't initialize compression library: %s"),
 				z.msg);
+#ifdef PG_CRC32C_H
+		INIT_CRC32C(crc);
+#else
 		INIT_CRC32(crc);
+#endif
 		read_size = 0;
 	}
 #endif
@@ -700,7 +737,11 @@ copy_file(const char *from_root, const char *to_root, pgFile *file,
 	char		outbuf[zlibOutSize];
 	char		inbuf[zlibInSize];
 #endif
+#ifdef PG_CRC32C_H
+	INIT_CRC32C(crc);
+#else
 	INIT_CRC32(crc);
+#endif
 
 	/* reset size summary */
 	file->read_size = 0;
@@ -710,7 +751,11 @@ copy_file(const char *from_root, const char *to_root, pgFile *file,
 	in = fopen(file->path, "r");
 	if (in == NULL)
 	{
+#ifdef PG_CRC32C_H
+		FIN_CRC32C(crc);
+#else
 		FIN_CRC32(crc);
+#endif
 		file->crc = crc;
 
 		/* maybe deleted, it's not error */
@@ -825,7 +870,11 @@ copy_file(const char *from_root, const char *to_root, pgFile *file,
 					strerror(errno_tmp));
 			}
 			/* update CRC */
+#ifdef PG_CRC32C_H
+			COMP_CRC32C(crc, buf, read_len);
+#else
 			COMP_CRC32(crc, buf, read_len);
+#endif
 
 			file->write_size += sizeof(buf);
 			file->read_size += sizeof(buf);
@@ -862,7 +911,11 @@ copy_file(const char *from_root, const char *to_root, pgFile *file,
 					strerror(errno_tmp));
 			}
 			/* update CRC */
+#ifdef PG_CRC32C_H
+			COMP_CRC32C(crc, buf, read_len);
+#else
 			COMP_CRC32(crc, buf, read_len);
+#endif
 
 			file->write_size += read_len;
 		}
@@ -900,7 +953,11 @@ copy_file(const char *from_root, const char *to_root, pgFile *file,
 
 #endif
 	/* finish CRC calculation and store into pgFile */
+#ifdef PG_CRC32C_H
+	FIN_CRC32C(crc);
+#else
 	FIN_CRC32(crc);
+#endif
 	file->crc = crc;
 
 	/* update file permission */

--- a/doc/pg_arman.txt
+++ b/doc/pg_arman.txt
@@ -104,10 +104,8 @@ write default configuration into ${BACKUP_PATH}/pg_arman.ini.
 
 	$ cat $BACKUP_PATH/pg_arman.ini
 	ARCLOG_PATH = /home/postgres/arclog
-	BACKUP_MODE = F
+	BACKUP_MODE = FULL
 	COMPRESS_DATA = YES
-	KEEP_ARCLOG_FILES = 10
-	KEEP_ARCLOG_DAYS = 10
 	KEEP_DATA_GENERATIONS = 3
 	KEEP_DATA_DAYS = 120
 
@@ -133,8 +131,8 @@ Here are some commands to restore from a backup:
 	===================================================================================
 	Start                Mode  Current TLI  Parent TLI  Time    Data   Backup   Status 
 	===================================================================================
-	2013-12-25 03:02:31  INCR            1           0    0m   203kB     67MB   DONE
-	2013-12-25 03:02:31  INCR            1           0    0m      0B       0B   ERROR
+	2013-12-25 03:02:31  PAGE            1           0    0m   203kB     67MB   DONE
+	2013-12-25 03:02:31  PAGE            1           0    0m      0B       0B   ERROR
 	2013-12-25 03:02:25  FULL            1           0    0m    33MB    364MB   OK
 
 The fields are:

--- a/pg_arman.h
+++ b/pg_arman.h
@@ -57,6 +57,10 @@
 #define ERROR_PG_RUNNING		25	/* PostgreSQL server is running */
 #define ERROR_PID_BROKEN		26	/* postmaster.pid file is broken */
 
+#ifdef PG_CRC32C_H
+#	define pg_crc32 pg_crc32c
+#endif
+
 /* backup mode file */
 typedef struct pgFile
 {

--- a/restore.c
+++ b/restore.c
@@ -679,13 +679,23 @@ get_current_timeline(void)
 	close(fd);
 
 	/* Check the CRC. */
+#ifdef PG_CRC32C_H
+	INIT_CRC32C(crc);
+	COMP_CRC32C(crc,
+				(char *) &ControlFile,
+				offsetof(ControlFileData, crc));
+	FIN_CRC32C(crc);
+
+	if (!EQ_CRC32C(crc, ControlFile.crc))
+#else
 	INIT_CRC32(crc);
 	COMP_CRC32(crc,
-		   	(char *) &ControlFile,
-		   	offsetof(ControlFileData, crc));
+			   (char *) &ControlFile,
+			   offsetof(ControlFileData, crc));
 	FIN_CRC32(crc);
 
 	if (!EQ_CRC32(crc, ControlFile.crc))
+#endif
 	{
 		elog(WARNING, _("Calculated CRC checksum does not match value stored in file.\n"
 			"Either the file is corrupt, or it has a different layout than this program\n"


### PR DESCRIPTION
After this commit https://github.com/postgres/postgres/commit/4f700bcd20c087f60346cb8aefd0e269be8e2157
postgres moving to new CRC32 functions for WAL and etc. 

Thanks.